### PR TITLE
Feature: Decoupling Grain module from kubernetes dependency

### DIFF
--- a/src/AeFinder.Application.Contracts/GraphQL/IGraphQLAppService.cs
+++ b/src/AeFinder.Application.Contracts/GraphQL/IGraphQLAppService.cs
@@ -6,7 +6,8 @@ namespace AeFinder.GraphQL;
 
 public interface IGraphQLAppService
 {
-    Task<HttpResponseMessage> RequestForwardAsync(string appId, string version, GraphQLQueryInput input);
+    Task<HttpResponseMessage> RequestForwardAsync(string appId, string version, string kubernetesOriginName,
+        GraphQLQueryInput input);
     Task<string> GetAppCurrentVersionCacheNameAsync(string appId);
     Task CacheAppCurrentVersionAsync(string appId, string currentVersion);
     Task<string> GetAppCurrentVersionCacheAsync(string appId);

--- a/src/AeFinder.Application/AeFinder.Application.csproj
+++ b/src/AeFinder.Application/AeFinder.Application.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="AElf.EntityMapping" Version="1.0.0-rc9.9" />
     <PackageReference Include="AElf.EntityMapping.Elasticsearch" Version="1.0.0-rc9.9" />
     <PackageReference Include="GraphQL.Client" Version="6.0.3" />
+    <PackageReference Include="IdentityModel.OidcClient" Version="5.2.1" />
     <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.6.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/AeFinder.Application/AeFinderApplicationModule.cs
+++ b/src/AeFinder.Application/AeFinderApplicationModule.cs
@@ -3,8 +3,6 @@ using AeFinder.BlockSync;
 using AeFinder.CodeOps;
 using AeFinder.CodeOps.Policies;
 using AeFinder.Grains;
-using AeFinder.Kubernetes;
-using AeFinder.Kubernetes.Manager;
 using AeFinder.Option;
 using AElf.EntityMapping;
 using AElf.EntityMapping.Elasticsearch;

--- a/src/AeFinder.Application/BlockScan/BlockScanAppService.cs
+++ b/src/AeFinder.Application/BlockScan/BlockScanAppService.cs
@@ -7,7 +7,6 @@ using AeFinder.Grains;
 using AeFinder.Grains.Grain.BlockPush;
 using AeFinder.Grains.Grain.BlockStates;
 using AeFinder.Grains.Grain.Subscriptions;
-using AeFinder.Kubernetes.Manager;
 using AeFinder.Studio;
 using Microsoft.Extensions.Logging;
 using Orleans;

--- a/src/AeFinder.Application/Studio/StudioService.cs
+++ b/src/AeFinder.Application/Studio/StudioService.cs
@@ -11,7 +11,6 @@ using AeFinder.Grains;
 using AeFinder.Grains.Grain.Apps;
 using AeFinder.Grains.Grain.BlockStates;
 using AeFinder.Grains.Grain.Subscriptions;
-using AeFinder.Kubernetes.Manager;
 using AeFinder.Option;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/src/AeFinder.BackgroundWorker/AeFinder.BackgroundWorker.csproj
+++ b/src/AeFinder.BackgroundWorker/AeFinder.BackgroundWorker.csproj
@@ -35,6 +35,7 @@
     <ItemGroup>
         <ProjectReference Include="..\AeFinder.Application.Contracts\AeFinder.Application.Contracts.csproj" />
         <ProjectReference Include="..\AeFinder.Application\AeFinder.Application.csproj" />
+        <ProjectReference Include="..\AeFinder.Kubernetes\AeFinder.Kubernetes.csproj" />
         <ProjectReference Include="..\AeFinder.MongoDB\AeFinder.MongoDB.csproj" />
     </ItemGroup>
 

--- a/src/AeFinder.BackgroundWorker/EventHandler/AppUpgradeHandler.cs
+++ b/src/AeFinder.BackgroundWorker/EventHandler/AppUpgradeHandler.cs
@@ -1,5 +1,4 @@
 using AeFinder.App.Deploy;
-using AeFinder.Kubernetes.Manager;
 using AeFinder.Studio.Eto;
 using Microsoft.Extensions.Logging;
 using Volo.Abp.DependencyInjection;

--- a/src/AeFinder.Grains/AeFinder.Grains.csproj
+++ b/src/AeFinder.Grains/AeFinder.Grains.csproj
@@ -19,7 +19,6 @@
 
     <ItemGroup>
       <ProjectReference Include="..\AeFinder.Application.Contracts\AeFinder.Application.Contracts.csproj" />
-        <ProjectReference Include="..\AeFinder.Kubernetes\AeFinder.Kubernetes.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AeFinder.Grains/AeFinderGrainsModule.cs
+++ b/src/AeFinder.Grains/AeFinderGrainsModule.cs
@@ -1,7 +1,5 @@
 ﻿using AeFinder.Grains.Grain.BlockPush;
 using AeFinder.Grains.Grain.Blocks;
-using AeFinder.Kubernetes;
-using AeFinder.Kubernetes.Manager;
 using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.Modularity;
 

--- a/src/AeFinder.HttpApi.Host/appsettings.apollo.json
+++ b/src/AeFinder.HttpApi.Host/appsettings.apollo.json
@@ -16,5 +16,5 @@
     //Default value is 30000. If the config fails to be obtained at startup and there is no local cache, wait until successful or timeout. ms
     "StartupTimeout": 30000
   },
-  "IsApolloEnabled": true
+  "IsApolloEnabled": false
 }

--- a/src/AeFinder.HttpApi.Host/appsettings.json
+++ b/src/AeFinder.HttpApi.Host/appsettings.json
@@ -16,7 +16,7 @@
     "OriginName": "https://k8s.cluster.com:32439"
   },
   "ConnectionStrings": {
-    "Default": "mongodb://admin:admin@localhost:27017/?retryWrites=false&maxPoolSize=555"
+    "Default": "mongodb://localhost:27017/?retryWrites=false&maxPoolSize=555"
   },
   "Redis": {
     "Configuration": "127.0.0.1"
@@ -40,7 +40,7 @@
   "Orleans": {
     "ClusterId":"dev",
     "ServiceId":"OrleansBasics",
-    "MongoDBClient":"mongodb://admin:admin@localhost:27017/?retryWrites=false&maxPoolSize=555",
+    "MongoDBClient":"mongodb://localhost:27017/?retryWrites=false&maxPoolSize=555",
     "DataBase":"AeFinderOrleansDB"
   },
   "Api": {

--- a/src/AeFinder.HttpApi/AeFinder.HttpApi.csproj
+++ b/src/AeFinder.HttpApi/AeFinder.HttpApi.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="JsonModelBinder" Version="2.1.1" />
     <PackageReference Include="Volo.Abp.Account.HttpApi" Version="7.0.0" />
     <PackageReference Include="Volo.Abp.AspNetCore.SignalR" Version="7.0.0" />
+    <PackageReference Include="Volo.Abp.Http.Client.IdentityModel" Version="7.0.0" />
     <PackageReference Include="Volo.Abp.Identity.HttpApi" Version="7.0.0" />
     <PackageReference Include="Volo.Abp.PermissionManagement.HttpApi" Version="7.0.0" />
     <PackageReference Include="Volo.Abp.TenantManagement.HttpApi" Version="7.0.0" />

--- a/src/AeFinder.HttpApi/AeFinder.HttpApi.csproj
+++ b/src/AeFinder.HttpApi/AeFinder.HttpApi.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="JsonModelBinder" Version="2.1.1" />
     <PackageReference Include="Volo.Abp.Account.HttpApi" Version="7.0.0" />
     <PackageReference Include="Volo.Abp.AspNetCore.SignalR" Version="7.0.0" />
-    <PackageReference Include="Volo.Abp.Http.Client.IdentityModel" Version="7.0.0" />
     <PackageReference Include="Volo.Abp.Identity.HttpApi" Version="7.0.0" />
     <PackageReference Include="Volo.Abp.PermissionManagement.HttpApi" Version="7.0.0" />
     <PackageReference Include="Volo.Abp.TenantManagement.HttpApi" Version="7.0.0" />

--- a/src/AeFinder.HttpApi/AeFinder.HttpApi.csproj
+++ b/src/AeFinder.HttpApi/AeFinder.HttpApi.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\AeFinder.Application.Contracts\AeFinder.Application.Contracts.csproj" />
     <ProjectReference Include="..\AeFinder.Grains\AeFinder.Grains.csproj" />
+    <ProjectReference Include="..\AeFinder.Kubernetes\AeFinder.Kubernetes.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AeFinder.HttpApi/Controllers/GraphqlController.cs
+++ b/src/AeFinder.HttpApi/Controllers/GraphqlController.cs
@@ -1,7 +1,9 @@
 using System.Threading.Tasks;
 using AeFinder.GraphQL;
 using AeFinder.GraphQL.Dto;
+using AeFinder.Kubernetes;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Volo.Abp;
 using Volo.Abp.AspNetCore.Mvc;
 
@@ -13,17 +15,21 @@ namespace AeFinder.Controllers;
 public class GraphqlController : AbpController
 {
     private readonly IGraphQLAppService _graphQLAppService;
+    private readonly KubernetesOptions _kubernetesOption;
 
-    public GraphqlController(IGraphQLAppService graphQLAppService)
+    public GraphqlController(IGraphQLAppService graphQLAppService,
+        IOptionsSnapshot<KubernetesOptions> kubernetesOption)
     {
         _graphQLAppService = graphQLAppService;
+        _kubernetesOption = kubernetesOption.Value;
     }
 
     [HttpPost("{appId}/{version?}")]
     public async Task<IActionResult> GraphqlForward([FromBody] GraphQLQueryInput input, string appId,
         string version = null)
     {
-        var response = await _graphQLAppService.RequestForwardAsync(appId, version, input);
+        var response =
+            await _graphQLAppService.RequestForwardAsync(appId, version, _kubernetesOption.OriginName, input);
 
         if (response.IsSuccessStatusCode)
         {

--- a/src/AeFinder.Silo/AeFinder.Silo.csproj
+++ b/src/AeFinder.Silo/AeFinder.Silo.csproj
@@ -39,6 +39,10 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
         </Content>
+        <None Remove="appsettings.json" />
+        <Content Include="appsettings.json">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
 </Project>

--- a/src/AeFinder.Silo/AeFinderSiloModule.cs
+++ b/src/AeFinder.Silo/AeFinderSiloModule.cs
@@ -1,7 +1,5 @@
 using AeFinder.App.Deploy;
 using AeFinder.Grains;
-using AeFinder.Kubernetes;
-using AeFinder.Kubernetes.Manager;
 using AeFinder.MongoDb;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,7 +28,7 @@ public class AeFinderOrleansSiloModule : AbpModule
         context.Services.AddHostedService<AeFinderHostedService>();
         ConfigureTokenCleanupService();
         ConfigureCache(configuration);
-        context.Services.AddTransient<IAppDeployManager, KubernetesAppManager>();
+        // context.Services.AddTransient<IAppDeployManager, KubernetesAppManager>();
     }
 
     //Disable TokenCleanupService

--- a/src/AeFinder.Silo/appsettings.apollo.json
+++ b/src/AeFinder.Silo/appsettings.apollo.json
@@ -15,5 +15,5 @@
     //Default value is 30000. If the config fails to be obtained at startup and there is no local cache, wait until successful or timeout. ms
     "StartupTimeout": 30000
   },
-  "IsApolloEnabled": true
+  "IsApolloEnabled": false
 }

--- a/src/AeFinder.Silo/appsettings.json
+++ b/src/AeFinder.Silo/appsettings.json
@@ -51,6 +51,21 @@
     "ReplicationFactor": 1,
     "MessageMaxBytes": 104857600
   },
+  "RabbitMQ": {
+    "Connections": {
+      "Default": {
+        "HostName": "localhost",
+        "Port": "5672",
+        "UserName": "guest",
+        "Password": "guest"
+      }
+    },
+    "EventBus": {
+      "ClientName": "AeFinder-Silo",
+      "ExchangeName": "AeFinder-BackGround",
+      "PrefetchCount": 20
+    }
+  },
   "AElfEntityMapping": {
     "CollectionPrefix": "AeFinder",
     "ShardInitSettings": [


### PR DESCRIPTION
close #30 
1. remove AeFinder.Kubernetes package dependency from AeFinder.Grains
2. fix app settings config in silo & other service for local test
3. import IdentityModel.OidcClient 5.2.1 package into AeFinder.Application project to fix IdentityModel version problem